### PR TITLE
Making @glennsl/bs-jest a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "dom"
   ],
   "dependencies": {
-    "@glennsl/bs-jest": "^0.4.8",
     "jest-dom": "^3.1.2"
+  },
+  "peerDependency": {
+    "@glennsl/bs-jest": "^0.4.8"
   },
   "devDependencies": {
     "@wyze/changelog": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,16 @@ $ yarn add --dev bs-jest-dom
 $ npm install --save-dev bs-jest-dom
 ```
 
+If you don't have `@glennsl/bs-jest` already installed run
+
+```sh
+$ yarn add --dev @glennsl/bs-jest
+
+# or..
+
+$ npm install --save-dev @glennsl/bs-jest
+```
+
 ## Usage
 
 #### Add to `bsconfig.json`

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ See [`src/__tests__`](src/__tests__) for some examples.
 ```sh
 $ git clone https://github.com/wyze/bs-jest-dom.git
 $ cd bs-jest-dom
+$ yarn add @glennsl/bs-jest # or `npm install @glennsl/bs-jest`
 $ yarn # or `npm install`
 ```
 

--- a/src/JestDom.re
+++ b/src/JestDom.re
@@ -38,7 +38,7 @@ let mapMod = f =>
   | `Not(expected) => `Not(f(expected));
 
 let toJestAssertion = expected =>
-  Jest.Expect.((() => expected)->Jest.Expect.expect->not_->toThrow);
+  Jest.Expect.((() => expected)->Jest.Expect.expect->not->toThrow);
 
 let affirm =
   fun

--- a/src/__tests__/JestDom_test.re
+++ b/src/__tests__/JestDom_test.re
@@ -37,7 +37,7 @@ test("not toBeDisabled", () =>
   render({|<button data-testid="button"></button>|})
   |> queryByTestId("button")
   |> expect
-  |> not_
+  |> not
   |> toBeDisabled
 );
 
@@ -52,7 +52,7 @@ test("not toBeEnabled", () =>
   render({|<button disabled data-testid="button"></button>|})
   |> queryByTestId("button")
   |> expect
-  |> not_
+  |> not
   |> toBeEnabled
 );
 
@@ -69,7 +69,7 @@ test("not toBeInTheDocument", () =>
     _ =>
       Document.createElement("div", document)->Some
       |> expect
-      |> not_
+      |> not
       |> toBeInTheDocument
   )
 );
@@ -85,7 +85,7 @@ test("not toBeVisible", () =>
   render({|<button style="display: none" data-testid="button"></button>|})
   |> queryByTestId("button")
   |> expect
-  |> not_
+  |> not
   |> toBeVisible
 );
 
@@ -105,7 +105,7 @@ test("not toContainElement", () => {
   element
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> Document.createElement("div", document)->Some->toContainElement;
 });
 
@@ -120,7 +120,7 @@ test("not toContainHTML", () =>
   render({|<span data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toContainHTML("<p></p>")
 );
 
@@ -135,7 +135,7 @@ test("not toHaveAttribute", () =>
   render({|<span data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveAttribute("class")
 );
 
@@ -150,7 +150,7 @@ test("not toHaveAttribute with value", () =>
   render({|<span class="hidden" data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveAttribute("class", ~value="empty")
 );
 
@@ -165,7 +165,7 @@ test("not toHaveClass", () =>
   render({|<span data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveClass("empty")
 );
 
@@ -180,7 +180,7 @@ test("not toHaveClassMany", () =>
   render({|<span class="hidden" data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveClassMany(["empty", "hidden"])
 );
 
@@ -199,7 +199,7 @@ test("not toHaveFocus", () =>
   render({|<span data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveFocus
 );
 
@@ -218,7 +218,7 @@ test("not toHaveFormValues", () =>
   )
   |> queryByTestId("form")
   |> expect
-  |> not_
+  |> not
   |> toHaveFormValues({"title": "CTO"})
 );
 
@@ -233,7 +233,7 @@ test("not toHaveStyle", () =>
   render({|<span style="display: none" data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveStyle("display: inline-block")
 );
 
@@ -248,7 +248,7 @@ test("not toHaveTextContent", () =>
   render({|<span data-testid="span">Step 2 of 4</span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveTextContent("Step 1 of 4")
 );
 
@@ -272,6 +272,6 @@ test("not toHaveTextContentRe", () =>
   render({|<span data-testid="span">Step 2 of 4</span>|})
   |> queryByTestId("span")
   |> expect
-  |> not_
+  |> not
   |> toHaveTextContentRe([%bs.re "/^\\d of 4$/"])
 );


### PR DESCRIPTION
When building a project that already has `@glennsl/bs-jest` you'll get a `Duplicate package:  @glennsl/bs-jest` error. Making `@glennsl/bs-jest` a peerDependency should fix this problem.

![duplicate_package](https://user-images.githubusercontent.com/2590831/56225423-dd73ee00-6060-11e9-8fae-f2f4086adc4c.png)
