### PR TITLE
Update toHaveClass/toHaveTextContent method signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,6 @@ jobs:
           deno-version: '0.40'
       - run: yarn install --frozen-lockfile
       - run: yarn --check-files
-      - run: deno run --allow-read --allow-write https://denopkg.com/wyze/conditional_bisect@v1.0.0/mod.ts
+      - run: deno run --allow-read --allow-write https://denopkg.com/wyze/conditional_bisect@v1.0.1/mod.ts
       - run: yarn test:coverage
       - run: yarn bisect-ppx-report send-to Codecov

--- a/src/JestDom.rei
+++ b/src/JestDom.rei
@@ -24,4 +24,3 @@ let toHaveStyle: (string, [< modifier(t)]) => Jest.assertion;
 let toHaveTextContent:
   ([`RegExp(Js.Re.t) | `Str(string)], ~options: TextContent.options=?, [< modifier(t)]) =>
   Jest.assertion;
-  Jest.assertion;

--- a/src/JestDom.rei
+++ b/src/JestDom.rei
@@ -12,20 +12,16 @@ let toBeDisabled: [< modifier(t)] => Jest.assertion;
 let toBeEnabled: [< modifier(t)] => Jest.assertion;
 let toBeInTheDocument: [< modifier(t)] => Jest.assertion;
 let toBeVisible: [< modifier(t)] => Jest.assertion;
-let toContainElement: (t, [< | `Just(t) | `Not(t)]) => Jest.assertion;
-let toContainHTML: (string, [< | `Just(t) | `Not(t)]) => Jest.assertion;
+let toContainElement: (t, [< modifier(t)]) => Jest.assertion;
+let toContainHTML: (string, [< modifier(t)]) => Jest.assertion;
 let toHaveAttribute:
-  (string, ~value: string=?, [< | `Just(t) | `Not(t)]) => Jest.assertion;
-let toHaveClass: (string, [< | `Just(t) | `Not(t)]) => Jest.assertion;
-let toHaveClassMany:
-  (list(string), [< | `Just(t) | `Not(t)]) => Jest.assertion;
+  (string, ~value: string=?, [< modifier(t)]) => Jest.assertion;
+let toHaveClass: ([`Str(string) | `Lst(list(string))], [< modifier(t)]) => Jest.assertion;
 let toHaveFocus: [< modifier(t)] => Jest.assertion;
 let toHaveFormValues:
-  (Js.t({..}), [< | `Just(t) | `Not(t)]) => Jest.assertion;
-let toHaveStyle: (string, [< | `Just(t) | `Not(t)]) => Jest.assertion;
+  (Js.t({..}), [< modifier(t)]) => Jest.assertion;
+let toHaveStyle: (string, [< modifier(t)]) => Jest.assertion;
 let toHaveTextContent:
-  (string, ~options: TextContent.options=?, [< | `Just(t) | `Not(t)]) =>
+  ([`RegExp(Js.Re.t) | `Str(string)], ~options: TextContent.options=?, [< modifier(t)]) =>
   Jest.assertion;
-let toHaveTextContentRe:
-  (Js.Re.t, ~options: TextContent.options=?, [< | `Just(t) | `Not(t)]) =>
   Jest.assertion;

--- a/src/__tests__/JestDom_test.re
+++ b/src/__tests__/JestDom_test.re
@@ -166,34 +166,34 @@ test("not toHaveAttribute with value", () =>
   |> toHaveAttribute("class", ~value="empty")
 );
 
-test("toHaveClass", () =>
+test("toHaveClass (string)", () =>
   render({|<span class="empty" data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> toHaveClass("empty")
+  |> toHaveClass(`Str("empty"))
 );
 
-test("not toHaveClass", () =>
+test("not toHaveClass (string)", () =>
   render({|<span data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
   |> not_
-  |> toHaveClass("empty")
+  |> toHaveClass(`Str("empty"))
 );
 
-test("toHaveClassMany", () =>
+test("toHaveClass (list)", () =>
   render({|<span class="empty hidden" data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
-  |> toHaveClassMany(["empty", "hidden"])
+  |> toHaveClass(`Lst(["empty", "hidden"]))
 );
 
-test("not toHaveClassMany", () =>
+test("not toHaveClass (list)", () =>
   render({|<span class="hidden" data-testid="span"></span>|})
   |> queryByTestId("span")
   |> expect
   |> not_
-  |> toHaveClassMany(["empty", "hidden"])
+  |> toHaveClass(`Lst(["empty", "hidden"]))
 );
 
 test("toHaveFocus", () => {
@@ -249,41 +249,41 @@ test("not toHaveStyle", () =>
   |> toHaveStyle("display: inline-block")
 );
 
-test("toHaveTextContent", () =>
+test("toHaveTextContent (string)", () =>
   render({|<span data-testid="span">Step 1 of 4</span>|})
   |> queryByTestId("span")
   |> expect
-  |> toHaveTextContent("Step 1 of 4")
+  |> toHaveTextContent(`Str("Step 1 of 4"))
 );
 
-test("not toHaveTextContent", () =>
+test("not toHaveTextContent (string)", () =>
   render({|<span data-testid="span">Step 2 of 4</span>|})
   |> queryByTestId("span")
   |> expect
   |> not_
-  |> toHaveTextContent("Step 1 of 4")
+  |> toHaveTextContent(`Str("Step 1 of 4"))
 );
 
-test("toHaveTextContent with options", () => {
+test("toHaveTextContent (string) with options", () => {
   let options = TextContent.makeOptions(~normalizeWhitespace=false, ());
 
   render({|<span data-testid="span">&nbsp;&nbsp;Step 1 of 4</span>|})
   |> queryByTestId("span")
   |> expect
-  |> toHaveTextContent("  Step 1 of 4", ~options);
+  |> toHaveTextContent(`Str("  Step 1 of 4"), ~options);
 });
 
-test("toHaveTextContentRe", () =>
+test("toHaveTextContent (regex)", () =>
   render({|<span data-testid="span">Step 1 of 4</span>|})
   |> queryByTestId("span")
   |> expect
-  |> toHaveTextContentRe([%bs.re "/Step \\d of \\d/"])
+  |> toHaveTextContent(`RegExp([%bs.re "/Step \\d of \\d/"]))
 );
 
-test("not toHaveTextContentRe", () =>
+test("not toHaveTextContent (regex)", () =>
   render({|<span data-testid="span">Step 2 of 4</span>|})
   |> queryByTestId("span")
   |> expect
   |> not_
-  |> toHaveTextContentRe([%bs.re "/^\\d of 4$/"])
+  |> toHaveTextContent(`RegExp([%bs.re "/^\\d of 4$/"]))
 );

--- a/src/__tests__/JestDom_test.re
+++ b/src/__tests__/JestDom_test.re
@@ -24,7 +24,7 @@ let queryByTestId = (id: string, element: Dom.element) =>
   | None => raise(Failure("Element not found"))
   };
 
-// afterAll(Bisect.Runtime.write_coverage_data);
+afterAll(Bisect.Runtime.write_coverage_data);
 
 afterEach(() =>
   switch (document->Document.unsafeAsHtmlDocument->HtmlDocument.body) {

--- a/src/__tests__/JestDom_test.re
+++ b/src/__tests__/JestDom_test.re
@@ -24,7 +24,7 @@ let queryByTestId = (id: string, element: Dom.element) =>
   | None => raise(Failure("Element not found"))
   };
 
-afterAll(Bisect.Runtime.write_coverage_data);
+// afterAll(Bisect.Runtime.write_coverage_data);
 
 afterEach(() =>
   switch (document->Document.unsafeAsHtmlDocument->HtmlDocument.body) {


### PR DESCRIPTION
- Remove toHaveClassMany and use variadic argument in toHaveClass
- Remove toHaveTextContentRe and use variadic argument in toHaveTextContent